### PR TITLE
fix: join roles & command error handling

### DIFF
--- a/src/interaction/events/interaction/slashCreate.ts
+++ b/src/interaction/events/interaction/slashCreate.ts
@@ -65,5 +65,15 @@ export default async function slashCreate(auxdibot: Auxdibot, interaction: ChatI
          'This command is invalid or incomplete! Please report this to our support server.',
          interaction,
       );
-   return await commandData.execute(auxdibot, interactionData);
+   try {
+      await commandData.execute(auxdibot, interactionData);
+   } catch (x) {
+      console.log(x);
+      return handleError(
+         auxdibot,
+         'COMMAND_ERROR',
+         'This command has produced an uncaught error! Please report this to our support server.',
+         interaction,
+      );
+   }
 }

--- a/src/interaction/subcommands/settings/join_roles/joinRoleAdd.ts
+++ b/src/interaction/subcommands/settings/join_roles/joinRoleAdd.ts
@@ -60,7 +60,7 @@ export const joinRoleAdd = <AuxdibotSubcommand>{
       if (!testLimit(server.join_roles, Limits.JOIN_ROLE_DEFAULT_LIMIT)) {
          return await handleError(auxdibot, 'JOIN_ROLES_LIMIT_EXCEEDED', 'You have too many join roles!', interaction);
       }
-      auxdibot.database.servers.update({
+      await auxdibot.database.servers.update({
          where: { serverID: server.serverID },
          data: { join_roles: { push: role.id } },
       });

--- a/src/interaction/subcommands/settings/join_roles/joinRoleRemove.ts
+++ b/src/interaction/subcommands/settings/join_roles/joinRoleRemove.ts
@@ -65,7 +65,7 @@ export const joinRoleRemove = <AuxdibotSubcommand>{
          );
       }
       server.join_roles.splice(server.join_roles.indexOf(joinRoleID), 1);
-      auxdibot.database.servers.update({
+      await auxdibot.database.servers.update({
          where: { serverID: server.serverID },
          data: { join_roles: server.join_roles },
       });


### PR DESCRIPTION
Fixxes include

* Join roles not being added because I forgot to await the async function.
* Join roles not being removed because I forgot to await the async function.
* Added in a try catch around command execution for uncaught errors so the bot won't crash on an uncaught exception