### PR TITLE
feat: schedules update & fix: schedule time drift

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,7 +39,7 @@ type APIEmbed {
   footer      APIEmbedFooter?
   thumbnail   APIEmbedImgThumbnail?
   image       APIEmbedImgThumbnail?
-  color       Int?
+  color       Int?                  @default(0)
   title       String?
   description String?
   type        String?               @default("rich")
@@ -97,6 +97,7 @@ enum LogAction {
   STARBOARD_REACTION_COUNT_CHANGED
   STARBOARD_MESSAGE_DELETED
   SCHEDULED_MESSAGE_CREATED
+  SCHEDULED_MESSAGE_EDITED
   SCHEDULED_MESSAGE_REMOVED
   LEVEL_CHANNEL_CHANGED
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -174,13 +174,15 @@ type Suggestion {
 }
 
 type ScheduledMessage {
-  channelID     String
-  last_run_unix Int?
-  times_run     Int?
-  interval_unix Int
-  embed         APIEmbed?
-  message       String?
-  times_to_run  Int?
+  channelID          String
+  old_last_run_unix  Int?      @map("last_run_unix")
+  old_interval_unix  Int?      @map("interval_unix")
+  interval_timestamp String    @default("1d")
+  last_run           DateTime? @default(now())
+  times_run          Int?
+  embed              APIEmbed?
+  message            String?
+  times_to_run       Int?
 }
 
 model servermembers {

--- a/src/constants/bot/log/LogNames.ts
+++ b/src/constants/bot/log/LogNames.ts
@@ -45,5 +45,6 @@ export const LogNames: { [k in LogAction]: string } = {
    STARBOARD_MESSAGE_DELETED: '⭐ Starboard Message Deleted',
    SCHEDULED_MESSAGE_CREATED: '⏲️ Scheduled Message Created',
    SCHEDULED_MESSAGE_REMOVED: '⏲️ Scheduled Message Deleted',
+   SCHEDULED_MESSAGE_EDITED: '⏲️ Scheduled Message Edited',
    LEVEL_CHANNEL_CHANGED: '🏆 Level Channel Changed',
 };

--- a/src/interaction/commands/messages/schedule.ts
+++ b/src/interaction/commands/messages/schedule.ts
@@ -7,6 +7,7 @@ import { scheduleMessage } from '@/interaction/subcommands/schedule/scheduleMess
 import { scheduleList } from '@/interaction/subcommands/schedule/scheduleList';
 import { scheduleRemove } from '@/interaction/subcommands/schedule/scheduleRemove';
 import { schedulePreview } from '@/interaction/subcommands/schedule/schedulePreview';
+import { scheduleEdit } from '@/interaction/subcommands/schedule/scheduleEdit';
 
 dotenv.config();
 export default <AuxdibotCommand>{
@@ -42,6 +43,31 @@ export default <AuxdibotCommand>{
                ),
          ),
       )
+      .addSubcommand((builder) =>
+         createEmbedParameters(
+            builder
+               .setName('edit')
+               .setDescription('Edit a scheduled message using Auxdibot.')
+               .addNumberOption((option) =>
+                  option
+                     .setName('index')
+                     .setDescription('The index of the scheduled message to edit. (See /schedule list)')
+                     .setRequired(true),
+               )
+               .addChannelOption((option) =>
+                  option
+                     .setName('channel')
+                     .setDescription('The channel to post the embed in.')
+                     .addChannelTypes(ChannelType.GuildText, ChannelType.GuildAnnouncement),
+               )
+               .addStringOption((option) => option.setName('interval').setDescription('Interval as a timestamp'))
+               .addNumberOption((option) =>
+                  option
+                     .setName('times_to_run')
+                     .setDescription('Times to run this schedule. Leave empty for infinite.'),
+               ),
+         ),
+      )
       .addSubcommand((builder) => builder.setName('list').setDescription('List the schedules running on your server.'))
       .addSubcommand((builder) =>
          builder
@@ -62,10 +88,10 @@ export default <AuxdibotCommand>{
    info: {
       module: Modules['Messages'],
       description: 'Schedule embeds, cancel schedules, and list schedules with Auxdibot.',
-      usageExample: '/schedule (message|remove|list|preview)',
+      usageExample: '/schedule (message|remove|list|preview|edit)',
       permission: 'schedule',
    },
-   subcommands: [scheduleMessage, scheduleList, scheduleRemove, schedulePreview],
+   subcommands: [scheduleMessage, scheduleList, scheduleRemove, schedulePreview, scheduleEdit],
    async execute() {
       return;
    },

--- a/src/interaction/commands/messages/schedule.ts
+++ b/src/interaction/commands/messages/schedule.ts
@@ -32,6 +32,13 @@ export default <AuxdibotCommand>{
                   option
                      .setName('times_to_run')
                      .setDescription('Times to run this schedule. Leave empty for infinite.'),
+               )
+               .addStringOption((option) =>
+                  option
+                     .setName('start_date')
+                     .setDescription(
+                        'The date to start running the schedule (normal date, ISO date, unix timestamp, etc.)',
+                     ),
                ),
          ),
       )

--- a/src/interaction/subcommands/schedule/scheduleEdit.ts
+++ b/src/interaction/subcommands/schedule/scheduleEdit.ts
@@ -1,0 +1,71 @@
+import Modules from '@/constants/bot/commands/Modules';
+import { Auxdibot } from '@/interfaces/Auxdibot';
+import { GuildAuxdibotCommandData } from '@/interfaces/commands/AuxdibotCommandData';
+import AuxdibotCommandInteraction from '@/interfaces/commands/AuxdibotCommandInteraction';
+import { AuxdibotSubcommand } from '@/interfaces/commands/AuxdibotSubcommand';
+import argumentsToEmbedParameters from '@/util/argumentsToEmbedParameters';
+import handleError from '@/util/handleError';
+import handleLog from '@/util/handleLog';
+import timestampToDuration from '@/util/timestampToDuration';
+import { toAPIEmbed } from '@/util/toAPIEmbed';
+import { EmbedBuilder } from '@discordjs/builders';
+import { APIEmbed, LogAction } from '@prisma/client';
+import { ChannelType } from 'discord.js';
+
+export const scheduleEdit = <AuxdibotSubcommand>{
+   name: 'edit',
+   info: {
+      module: Modules['Messages'],
+      usageExample:
+         '/schedule edit (index) [channel] [timestamp] [times_to_run] [content] [color] [title] [title url] [author] [author icon url] [author url] [description] [fields (split title and description with `"|d|"``, and seperate fields with `"|s|"`)] [footer] [footer icon url] [image url] [thumbnail url]',
+      description: 'Edit an existing Schedule by Auxdibot.',
+      permission: 'schedule.edit',
+   },
+   async execute(auxdibot: Auxdibot, interaction: AuxdibotCommandInteraction<GuildAuxdibotCommandData>) {
+      if (!interaction.data) return;
+      const index = interaction.options.getNumber('index', true);
+      const interval = interaction.options.getString('interval'),
+         times_to_run = interaction.options.getNumber('times_to_run'),
+         channel = interaction.options.getChannel('channel', false, [
+            ChannelType.GuildText,
+            ChannelType.GuildAnnouncement,
+         ]);
+      const parameters = argumentsToEmbedParameters(interaction);
+      const server = interaction.data.guildData;
+
+      const schedule = server.scheduled_messages.find((_val, valIndex) => valIndex == index - 1);
+      if (!schedule) {
+         return await handleError(auxdibot, 'SCHEDULE_NOT_FOUND', "Couldn't find that schedule!", interaction);
+      }
+      if (Object.keys(parameters).find((i) => !!parameters[i])) schedule.embed = toAPIEmbed(parameters) as APIEmbed;
+      if (interval) {
+         const duration = timestampToDuration(interval);
+
+         if (!duration || duration == 'permanent') {
+            return await handleError(
+               auxdibot,
+               'INVALID_TIMESTAMP',
+               'The timestamp provided is invalid! (Examples of valid timestamps: "1m" for 1 minute, "5d" for 5 days.)',
+               interaction,
+            );
+         }
+         schedule.interval_timestamp = interval;
+      }
+      if (times_to_run) schedule.times_to_run = times_to_run;
+      if (channel) schedule.channelID = channel.id;
+      await auxdibot.database.servers.update({
+         where: { serverID: server.serverID },
+         data: { scheduled_messages: server.scheduled_messages },
+      });
+      await handleLog(auxdibot, interaction.data.guild, {
+         userID: interaction.data.member.id,
+         description: `Edited scheduled message #${index}.`,
+         type: LogAction.SCHEDULED_MESSAGE_EDITED,
+         date_unix: Date.now(),
+      });
+      const success_embed = new EmbedBuilder().setColor(auxdibot.colors.accept).toJSON();
+      success_embed.title = 'Success!';
+      success_embed.description = `Edited schedule #${index}.`;
+      return await interaction.reply({ embeds: [success_embed] });
+   },
+};

--- a/src/interaction/subcommands/schedule/scheduleList.ts
+++ b/src/interaction/subcommands/schedule/scheduleList.ts
@@ -1,3 +1,4 @@
+import timestampToDuration from '@/util/timestampToDuration';
 import Modules from '@/constants/bot/commands/Modules';
 import { Auxdibot } from '@/interfaces/Auxdibot';
 import { GuildAuxdibotCommandData } from '@/interfaces/commands/AuxdibotCommandData';
@@ -21,7 +22,7 @@ export const scheduleList = <AuxdibotSubcommand>{
       successEmbed.description = server.scheduled_messages.reduce(
          (accumulator: string, value, index) =>
             `${accumulator}\r\n\r\n**${index + 1})** Channel: <#${value.channelID}> (next run <t:${Math.round(
-               ((value.last_run_unix || Date.now()) + value.interval_unix) / 1000,
+               (value.last_run.valueOf() + (Number(timestampToDuration(value.interval_timestamp)) || 0)) / 1000,
             )}:R>)`,
          '',
       );

--- a/src/interaction/subcommands/schedule/scheduleList.ts
+++ b/src/interaction/subcommands/schedule/scheduleList.ts
@@ -21,10 +21,12 @@ export const scheduleList = <AuxdibotSubcommand>{
       successEmbed.title = '⏲️ Schedules';
       successEmbed.description = server.scheduled_messages.reduce(
          (accumulator: string, value, index) =>
-            `${accumulator}\r\n\r\n**${index + 1})** Channel: <#${value.channelID}> (next run <t:${Math.round(
+            `${accumulator}\r\n\r\n**${index + 1})** Channel: <#${value.channelID}> \`${
+               value.interval_timestamp
+            }\` (next run <t:${Math.round(
                (value.last_run.valueOf() + (Number(timestampToDuration(value.interval_timestamp)) || 0)) / 1000,
             )}:R>)`,
-         '',
+         'Use `/schedule preview (index)` to preview any schedule!',
       );
       return await interaction.reply({ embeds: [successEmbed] });
    },

--- a/src/interaction/subcommands/schedule/scheduleMessage.ts
+++ b/src/interaction/subcommands/schedule/scheduleMessage.ts
@@ -26,7 +26,8 @@ export const scheduleMessage = <AuxdibotSubcommand>{
       if (!interaction.data) return;
       const channel = interaction.options.getChannel('channel', true, [ChannelType.GuildText]),
          interval = interaction.options.getString('interval', true),
-         times_to_run = interaction.options.getNumber('times_to_run');
+         times_to_run = interaction.options.getNumber('times_to_run'),
+         start_date = interaction.options.getString('start_date');
       if (interaction.data.guildData.scheduled_messages.length >= Limits.SCHEDULE_LIMIT) {
          return await handleError(
             auxdibot,
@@ -45,15 +46,20 @@ export const scheduleMessage = <AuxdibotSubcommand>{
             interaction,
          );
       }
-
+      const startDate = new Date(start_date);
+      if (!(startDate instanceof Date && !isNaN(startDate.valueOf())) && start_date) {
+         return await handleError(auxdibot, 'INVALID_DATE', 'The start date provided is invalid!', interaction);
+      }
       const content = interaction.options.getString('content')?.replace(/\\n/g, '\n') || '';
       const parameters = argumentsToEmbedParameters(interaction);
       try {
          const scheduledMessage = <ScheduledMessage>{
-            interval_unix: duration,
+            interval_timestamp: interval,
             message: content,
             embed: toAPIEmbed(parameters),
-            last_run_unix: Date.now() - duration,
+            last_run: new Date(
+               (startDate instanceof Date && !isNaN(startDate.valueOf()) ? startDate.valueOf() : Date.now()) - duration,
+            ),
             times_to_run,
             times_run: 0,
             channelID: channel.id,

--- a/src/util/addTimestampToDate.ts
+++ b/src/util/addTimestampToDate.ts
@@ -1,0 +1,29 @@
+export default function addTimestampToDate(date: Date, timestamp: string): Date {
+   const match = timestamp.match(/\d+|[mhdwMy]/g);
+   if (!match || match.length != 2) return undefined;
+   const [time, stamp] = match;
+   const updatedDate = new Date(date.valueOf());
+   switch (stamp) {
+      case 'm':
+         updatedDate.setMinutes(date.getMinutes() + Number(time));
+         break;
+      case 'h':
+         updatedDate.setUTCHours(date.getHours() + Number(time));
+         break;
+      case 'M':
+         updatedDate.setMonth(date.getMonth() + Number(time));
+         break;
+      case 'w':
+         updatedDate.setDate(date.getDate() + Number(time) * 7);
+         break;
+      case 'y':
+         updatedDate.setFullYear(date.getFullYear() + Number(time));
+         break;
+      case 'd':
+         updatedDate.setDate(date.getDate() + Number(time));
+         break;
+      default:
+         break;
+   }
+   return updatedDate;
+}

--- a/src/util/durationToTimestamp.ts
+++ b/src/util/durationToTimestamp.ts
@@ -1,0 +1,14 @@
+export default function durationToTimestamp(duration: number): string | undefined {
+   const SYMBOLS = {
+      m: 60 * 1000,
+      h: 60 * 60 * 1000,
+      d: 24 * 60 * 60 * 1000,
+      w: 7 * 24 * 60 * 60 * 1000,
+      M: 3.345 * 24 * 60 * 60 * 1000,
+      y: 12 * 3.345 * 24 * 60 * 60 * 1000,
+   };
+   for (const i in SYMBOLS) {
+      if (duration % SYMBOLS[i] == 0) return `${duration / SYMBOLS[i]}${i}`;
+   }
+   return undefined;
+}


### PR DESCRIPTION
* Schedules time drift has been fixed. Switching to using `DateTime` from using `Int` types with unix timestamps.
* Updated the `/schedules list` command.
* The timestamp is now stored for a schedule under `interval_timestamp`
* Schedules will (hopefully) automatically migrate to the new system