### PR TITLE
feat: deprecating /mute_role, update mute role command

### DIFF
--- a/src/modules/features/moderation/setMuteRole.ts
+++ b/src/modules/features/moderation/setMuteRole.ts
@@ -9,6 +9,32 @@ export default async function setMuteRole(
    user: { id: string },
    role?: Role | APIRole,
 ) {
+   const guildRole = role ? guild.roles.cache.get(role.id) : null;
+   if (guildRole) {
+      await guildRole.setPermissions([], 'Clearing all permissions.').catch(() => undefined);
+      guild.channels.cache.forEach((r) => {
+         if (r.isDMBased() || r.isThread() || !guildRole) return;
+         r.permissionOverwrites
+            .create(guildRole, {
+               SendMessages: false,
+               SendMessagesInThreads: false,
+               AddReactions: false,
+               CreatePublicThreads: false,
+               AttachFiles: false,
+               EmbedLinks: false,
+               CreatePrivateThreads: false,
+               CreateInstantInvite: false,
+               ChangeNickname: false,
+            })
+            .catch(() => undefined);
+         if (r.isVoiceBased())
+            r.permissionOverwrites
+               .create(guildRole, {
+                  Connect: false,
+               })
+               .catch(() => undefined);
+      });
+   }
    return auxdibot.database.servers
       .update({
          where: { serverID: guild.id },

--- a/src/server/servers/routes/muteRole.ts
+++ b/src/server/servers/routes/muteRole.ts
@@ -6,6 +6,8 @@ import { Router } from 'express';
 /*
    Mute Role
    Change the mute role and view it for the server.
+
+   TODO: This endpoint will be deprecated upon dashboard automod update
 */
 const muteRole = (auxdibot: Auxdibot, router: Router) => {
    // todo for backwards compatability purposes until the dashboard website is updated


### PR DESCRIPTION
* deprecated mute_role endpoint
* updated mute role command to use permissions in the setMuteRole method
* dashboard muterole will now set muterole permissions
* mute role will no longer allow users to create threads, change nicknames, embed files, and attach links.