### PR TITLE
fix: reaction role bugs

### DIFF
--- a/src/interaction/subcommands/roles/reactionRoles/reactionRolesRemove.ts
+++ b/src/interaction/subcommands/roles/reactionRoles/reactionRolesRemove.ts
@@ -40,11 +40,7 @@ export const reactionRolesRemove = <AuxdibotSubcommand>{
          message_channel && message_channel.isTextBased()
             ? message_channel.messages.cache.get(rr.messageID)
             : await getMessage(interaction.data.guild, rr.messageID);
-
-      if (message) {
-         await message.delete();
-      }
-      removeReactionRole(auxdibot, interaction.guild, index - 1, interaction.user)
+      removeReactionRole(auxdibot, interaction.guild, server.reaction_roles.indexOf(rr), interaction.user)
          .then(async () => {
             const successEmbed = new EmbedBuilder().setColor(auxdibot.colors.accept).toJSON();
             successEmbed.title = '👈 Deleted Reaction Role';

--- a/src/modules/features/roles/reaction_roles/removeReactionRole.ts
+++ b/src/modules/features/roles/reaction_roles/removeReactionRole.ts
@@ -25,7 +25,7 @@ export default async function removeReactionRole(
          if (message) message.delete();
          data.reaction_roles.splice(Number(index), 1);
          await handleLog(auxdibot, guild, {
-            userID: user.id || auxdibot.user.id,
+            userID: user?.id || auxdibot.user.id,
             description: `Deleted a reaction role${
                channel && !channel.isDMBased() ? ` in ${channel.name || 'a channel'}` : ''
             }.`,


### PR DESCRIPTION
Fixes bugs stated in #127 

* Fixed deletion of reaction roles message not deleting reaction role object from database
* Fixed deletion of reaction roles using message ID not deleting message
* Fixed creation of reaction roles causing an error then leaving the message. delete that thing!