### PR TITLE
feat: add reason length for punishments

### DIFF
--- a/src/interaction/subcommands/moderation/moderation/attachments/attachmentsPunishment.ts
+++ b/src/interaction/subcommands/moderation/moderation/attachments/attachmentsPunishment.ts
@@ -42,6 +42,14 @@ export const attachmentsPunishment = <AuxdibotSubcommand>{
             interaction,
          );
       }
+      if (reason.length > 500) {
+         return await handleError(
+            auxdibot,
+            'REASON_TOO_LONG',
+            'The reason specified is too long! (Max characters: 500)',
+            interaction,
+         );
+      }
       return auxdibot.database.servers
          .update({
             where: { serverID: server.serverID },

--- a/src/interaction/subcommands/moderation/moderation/invites/invitesPunishment.ts
+++ b/src/interaction/subcommands/moderation/moderation/invites/invitesPunishment.ts
@@ -42,6 +42,14 @@ export const invitesPunishment = <AuxdibotSubcommand>{
             interaction,
          );
       }
+      if (reason.length > 500) {
+         return await handleError(
+            auxdibot,
+            'REASON_TOO_LONG',
+            'The reason specified is too long! (Max characters: 500)',
+            interaction,
+         );
+      }
       return auxdibot.database.servers
          .update({
             where: { serverID: server.serverID },

--- a/src/interaction/subcommands/moderation/moderation/spam/spamPunishment.ts
+++ b/src/interaction/subcommands/moderation/moderation/spam/spamPunishment.ts
@@ -42,6 +42,14 @@ export const spamPunishment = <AuxdibotSubcommand>{
             interaction,
          );
       }
+      if (reason.length > 500) {
+         return await handleError(
+            auxdibot,
+            'REASON_TOO_LONG',
+            'The reason specified is too long! (Max characters: 500)',
+            interaction,
+         );
+      }
       return auxdibot.database.servers
          .update({
             where: { serverID: server.serverID },

--- a/src/interaction/subcommands/moderation/punish/punishBan.ts
+++ b/src/interaction/subcommands/moderation/punish/punishBan.ts
@@ -81,11 +81,11 @@ export const punishBan = <AuxdibotSubcommand>{
          member.user,
          duration,
          deleteMessageDays,
-      ).catch(async () => {
-         return await handleError(
+      ).catch(async (x) => {
+         await handleError(
             auxdibot,
-            'FAILED_BAN_USER',
-            "Couldn't ban that user. Check if they have a higher role than Auxdibot.",
+            'PUNISHMENT_CREATION_ERROR',
+            x.message ?? 'An unknown error occurred while creating the punishment!',
             interaction,
          );
       });

--- a/src/interaction/subcommands/moderation/punish/punishKick.ts
+++ b/src/interaction/subcommands/moderation/punish/punishKick.ts
@@ -44,8 +44,13 @@ export const punishKick = <AuxdibotSubcommand>{
          moderatorID: interaction.user.id,
          punishmentID: await incrementPunishmentsTotal(auxdibot, interaction.data.guildData.serverID),
       };
-      await createPunishment(auxdibot, interaction.data.guild, kickData, interaction, member.user).catch(async () => {
-         return await handleError(auxdibot, 'FAILED_KICK_USER', "Couldn't kick that user.", interaction);
+      await createPunishment(auxdibot, interaction.data.guild, kickData, interaction, member.user).catch(async (x) => {
+         await handleError(
+            auxdibot,
+            'PUNISHMENT_CREATION_ERROR',
+            x.message ?? 'An unknown error occurred while creating the punishment!',
+            interaction,
+         );
       });
    },
 };

--- a/src/interaction/subcommands/moderation/punish/punishMute.ts
+++ b/src/interaction/subcommands/moderation/punish/punishMute.ts
@@ -81,11 +81,11 @@ export const punishMute = <AuxdibotSubcommand>{
          punishmentID: await incrementPunishmentsTotal(auxdibot, server.serverID),
       };
       await createPunishment(auxdibot, interaction.data.guild, muteData, interaction, user, duration).catch(
-         async () => {
-            return await handleError(
+         async (x) => {
+            await handleError(
                auxdibot,
-               'FAILED_MUTE_USER',
-               `Could not mute this user! Check and see if Auxdibot has the Manage Roles (or Timeout Members) permission, or if the mute role is above Auxdibot in the role hierarchy.`,
+               'PUNISHMENT_CREATION_ERROR',
+               x.message ?? 'An unknown error occurred while creating the punishment!',
                interaction,
             );
          },

--- a/src/interaction/subcommands/moderation/punish/punishWarn.ts
+++ b/src/interaction/subcommands/moderation/punish/punishWarn.ts
@@ -45,6 +45,13 @@ export const punishWarn = <AuxdibotSubcommand>{
          punishmentID: await incrementPunishmentsTotal(auxdibot, interaction.data.guild.id),
       };
 
-      await createPunishment(auxdibot, interaction.data.guild, warnData, interaction, member.user);
+      await createPunishment(auxdibot, interaction.data.guild, warnData, interaction, member.user).catch(async (x) => {
+         await handleError(
+            auxdibot,
+            'PUNISHMENT_CREATION_ERROR',
+            x.message ?? 'An unknown error occurred while creating the punishment!',
+            interaction,
+         );
+      });
    },
 };

--- a/src/server/servers/routes/moderation.ts
+++ b/src/server/servers/routes/moderation.ts
@@ -262,7 +262,7 @@ const moderation = (auxdibot: Auxdibot, router: Router) => {
       (req, res) => {
          const punishment = req.body['punishment'],
             reason = req.body['reason'];
-
+         if (reason.length > 500) return res.status(400).json({ error: 'Your reason specified is too long!' });
          return auxdibot.database.servers
             .update({
                where: { serverID: req.guild.id },
@@ -288,7 +288,7 @@ const moderation = (auxdibot: Auxdibot, router: Router) => {
             reason = req.body['reason'];
          if (typeof punishment != 'string' || !PunishmentType[punishment])
             return res.status(400).json({ error: 'This is not a valid punishment!' });
-
+         if (reason.length > 500) return res.status(400).json({ error: 'Your reason specified is too long!' });
          return auxdibot.database.servers
             .update({
                where: { serverID: req.guild.id },
@@ -314,7 +314,7 @@ const moderation = (auxdibot: Auxdibot, router: Router) => {
             reason = req.body['reason'];
          if (typeof punishment != 'string' || !PunishmentType[punishment])
             return res.status(400).json({ error: 'This is not a valid punishment!' });
-
+         if (reason.length > 500) return res.status(400).json({ error: 'Your reason specified is too long!' });
          return auxdibot.database.servers
             .update({
                where: { serverID: req.guild.id },


### PR DESCRIPTION
* set punishment reason limit of 500
* set punishment reason length to 500 for spam, attachments, invite punishment commands and endpoints.
* add error handling to punishments.