### PR TITLE
fix: reaction roles deletion & rate limit increase

### DIFF
--- a/src/modules/features/roles/reaction_roles/removeReactionRole.ts
+++ b/src/modules/features/roles/reaction_roles/removeReactionRole.ts
@@ -22,7 +22,7 @@ export default async function removeReactionRole(
             channel && channel.isTextBased()
                ? await channel.messages.fetch(reactionRole.messageID).catch(() => undefined)
                : undefined;
-         if (message) message.delete().catch(() => undefined);
+
          data.reaction_roles.splice(Number(index), 1);
          await handleLog(auxdibot, guild, {
             userID: user?.id ?? auxdibot.user.id,
@@ -32,10 +32,12 @@ export default async function removeReactionRole(
             type: LogAction.REACTION_ROLE_REMOVED,
             date_unix: Date.now(),
          });
-         return await auxdibot.database.servers.update({
+         const result = await auxdibot.database.servers.update({
             where: { serverID: guild.id },
             data: { reaction_roles: data.reaction_roles },
          });
+         if (message) message.delete().catch(() => undefined);
+         return result;
       })
       .catch((x) => {
          throw new Error(x.message ?? 'an error occurred');

--- a/src/server/rateLimiter.ts
+++ b/src/server/rateLimiter.ts
@@ -2,7 +2,7 @@ import rateLimit from 'express-rate-limit';
 
 const rateLimiter = rateLimit({
    windowMs: 30 * 1000,
-   max: 100,
+   max: 150,
    legacyHeaders: false,
    standardHeaders: 'draft-7',
    handler: function (req, res, next) {


### PR DESCRIPTION
* reaction roles being deleted would cause it to delete the one after as well and a cascade effect happened
* increased rate limit due to dashboard bugging