### PR TITLE
feat: webhook user embeds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "auxdibot",
-   "version": "2.7.0",
+   "version": "2.7.1",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
          "name": "auxdibot",
-         "version": "2.7.0",
+         "version": "2.7.1",
          "license": "MPL-2.0",
          "dependencies": {
             "@prisma/client": "^4.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "auxdibot",
-   "version": "2.7.0",
+   "version": "2.7.1",
    "description": "Main repo for the Auxdibot discord.js bot, utilizing TypeScript and express for endpoints.",
    "main": "./dist/index.js",
    "scripts": {

--- a/src/interaction/commands/messages/embed.ts
+++ b/src/interaction/commands/messages/embed.ts
@@ -26,6 +26,8 @@ export default <AuxdibotCommand>{
                      .addChannelTypes(ChannelType.GuildText, ChannelType.GuildAnnouncement)
                      .setRequired(true),
                ),
+         ).addStringOption((option) =>
+            option.setName('webhook_url').setDescription('The Webhook URL to use for sending the Embed. (Optional)'),
          ),
       )
       .addSubcommand((builder) =>
@@ -44,6 +46,9 @@ export default <AuxdibotCommand>{
                   .setName('json')
                   .setDescription('The JSON data to use for creating the Discord Embed.')
                   .setRequired(true),
+            )
+            .addStringOption((option) =>
+               option.setName('webhook_url').setDescription('The Webhook URL to use for sending the Embed. (Optional)'),
             ),
       )
       .addSubcommand((builder) =>

--- a/src/interaction/commands/roles/reaction_roles.ts
+++ b/src/interaction/commands/roles/reaction_roles.ts
@@ -42,6 +42,11 @@ export default <AuxdibotCommand>{
                )
                .addStringOption((argBuilder) =>
                   argBuilder.setName('title').setDescription('Title of the reaction roles.'),
+               )
+               .addStringOption((argBuilder) =>
+                  argBuilder
+                     .setName('webhook_url')
+                     .setDescription('The Webhook URL to use for sending the Embed. (Optional)'),
                ),
          ),
       )
@@ -89,6 +94,10 @@ export default <AuxdibotCommand>{
                         .setRequired(true),
                   ),
             ),
+         ).addStringOption((argBuilder) =>
+            argBuilder
+               .setName('webhook_url')
+               .setDescription('The Webhook URL to use for sending the Embed. (Optional)'),
          ),
       )
       .addSubcommand((builder) =>
@@ -115,6 +124,10 @@ export default <AuxdibotCommand>{
                      .setDescription('The JSON for the Discord Embed attached to the reaction role.')
                      .setRequired(true),
                ),
+         ).addStringOption((argBuilder) =>
+            argBuilder
+               .setName('webhook_url')
+               .setDescription('The Webhook URL to use for sending the Embed. (Optional)'),
          ),
       )
       .addSubcommand((builder) =>

--- a/src/interaction/subcommands/embeds/createEmbed.ts
+++ b/src/interaction/subcommands/embeds/createEmbed.ts
@@ -16,13 +16,14 @@ export const createEmbed = <AuxdibotSubcommand>{
    info: {
       module: Modules['Messages'],
       usageExample:
-         '/embed create (channel) [content] [color] [title] [title url] [author] [author icon url] [author url] [description] [fields (split title and description with `"|d|"``, and seperate fields with `"|s|"`)] [footer] [footer icon url] [image url] [thumbnail url]',
+         '/embed create (channel) [webhook_url] [content] [color] [title] [title url] [author] [author icon url] [author url] [description] [fields (split title and description with `"|d|"``, and seperate fields with `"|s|"`)] [footer] [footer icon url] [image url] [thumbnail url]',
       description: 'Create an embed with Auxdibot.',
    },
    async execute(auxdibot: Auxdibot, interaction: AuxdibotCommandInteraction<GuildAuxdibotCommandData>) {
       if (!interaction.data) return;
       const channel = interaction.options.getChannel('channel', true, [ChannelType.GuildText]);
       const content = interaction.options.getString('content')?.replace(/\\n/g, '\n') || '';
+      const webhook_url = interaction.options.getString('webhook_url');
       const parameters = argumentsToEmbedParameters(interaction);
 
       try {
@@ -40,10 +41,17 @@ export const createEmbed = <AuxdibotSubcommand>{
             channel,
             await parsePlaceholders(auxdibot, content, interaction.data.guild, interaction.data.member),
             apiEmbed,
+            webhook_url,
          );
       } catch (x) {
-         console.error(x);
-         return await handleError(auxdibot, 'EMBED_SEND_ERROR', 'There was an error sending that embed!', interaction);
+         return await handleError(
+            auxdibot,
+            'EMBED_SEND_ERROR',
+            typeof x === 'object' && 'message' in x
+               ? (x as { message: string }).message
+               : 'There was an error sending that embed!',
+            interaction,
+         );
       }
 
       const embed = new EmbedBuilder().setColor(auxdibot.colors.accept).toJSON();

--- a/src/interaction/subcommands/embeds/createEmbedJSON.ts
+++ b/src/interaction/subcommands/embeds/createEmbedJSON.ts
@@ -13,24 +13,27 @@ export const createEmbedJSON = <AuxdibotSubcommand>{
    name: 'create_json',
    info: {
       module: Modules['Messages'],
-      usageExample: '/embed create_json (channel) (json)',
+      usageExample: '/embed create_json (channel) (json) [webhook_url]',
       description: 'Create an embed with Auxdibot using valid Discord Embed JSON data.',
    },
    async execute(auxdibot: Auxdibot, interaction: AuxdibotCommandInteraction<GuildAuxdibotCommandData>) {
       if (!interaction.data) return;
       const channel = interaction.options.getChannel('channel', true, [ChannelType.GuildText]);
       const json = interaction.options.getString('json', true);
+      const webhook_url = interaction.options.getString('webhook_url');
       try {
          const apiEmbed = JSON.parse(
             await parsePlaceholders(auxdibot, json, interaction.data.guild, interaction.data.member),
          ) satisfies APIEmbed;
 
-         await sendEmbed(channel, undefined, apiEmbed);
+         await sendEmbed(channel, undefined, apiEmbed, webhook_url);
       } catch (x) {
          return await handleError(
             auxdibot,
             'EMBED_SEND_ERROR_JSON',
-            'There was an error sending that embed! (Most likely due to malformed JSON.)',
+            typeof x === 'object' && 'message' in x
+               ? (x as { message: string }).message
+               : 'There was an error sending that embed!',
             interaction,
          );
       }

--- a/src/interaction/subcommands/roles/reactionRoles/reactionRolesAdd.ts
+++ b/src/interaction/subcommands/roles/reactionRoles/reactionRolesAdd.ts
@@ -24,7 +24,8 @@ export const reactionRolesAdd = <AuxdibotSubcommand>{
       const channel = interaction.options.getChannel('channel', true, [ChannelType.GuildText]),
          roles = interaction.options.getString('roles', true),
          title = interaction.options.getString('title') || 'React to receive roles!',
-         type = interaction.options.getString('type', false) || 'DEFAULT';
+         type = interaction.options.getString('type', false) || 'DEFAULT',
+         webhook_url = interaction.options.getString('webhook_url');
       const split = roles.split(' ');
       const builder = [];
       if (!testLimit(interaction.data.guildData.reaction_roles, Limits.REACTION_ROLE_DEFAULT_LIMIT)) {
@@ -59,6 +60,7 @@ export const reactionRolesAdd = <AuxdibotSubcommand>{
          undefined,
          undefined,
          ReactionRoleType[type],
+         webhook_url,
       )
          .then(async () => {
             const resEmbed = new EmbedBuilder().setColor(auxdibot.colors.accept).toJSON();
@@ -72,13 +74,13 @@ export const reactionRolesAdd = <AuxdibotSubcommand>{
             });
             return await auxdibot.createReply(interaction, { embeds: [resEmbed] });
          })
-         .catch((x) =>
+         .catch((x) => {
             handleError(
                auxdibot,
                'REACTION_ROLE_CREATE_ERROR',
                typeof x.message == 'string' ? x.message : "Couldn't create that reaction role!",
                interaction,
-            ),
-         );
+            );
+         });
    },
 };

--- a/src/interaction/subcommands/roles/reactionRoles/reactionRolesAddCustom.ts
+++ b/src/interaction/subcommands/roles/reactionRoles/reactionRolesAddCustom.ts
@@ -27,7 +27,8 @@ export const reactionRolesAddCustom = <AuxdibotSubcommand>{
       const channel = interaction.options.getChannel('channel', true, [ChannelType.GuildText]),
          roles = interaction.options.getString('roles', true),
          content = interaction.options.getString('content')?.replace(/\\n/g, '\n') || '',
-         type = interaction.options.getString('type', false) || 'DEFAULT';
+         type = interaction.options.getString('type', false) || 'DEFAULT',
+         webhook_url = interaction.options.getString('webhook_url');
       if (!testLimit(interaction.data.guildData.reaction_roles, Limits.REACTION_ROLE_DEFAULT_LIMIT)) {
          return await handleError(
             auxdibot,
@@ -73,6 +74,7 @@ export const reactionRolesAddCustom = <AuxdibotSubcommand>{
          ),
          await parsePlaceholders(auxdibot, JSON.stringify(parameters), interaction.data.guild, interaction.data.member),
          ReactionRoleType[type],
+         webhook_url,
       )
          .then(async () => {
             const resEmbed = new EmbedBuilder().setColor(auxdibot.colors.accept).toJSON();

--- a/src/interaction/subcommands/roles/reactionRoles/reactionRolesAddJSON.ts
+++ b/src/interaction/subcommands/roles/reactionRoles/reactionRolesAddJSON.ts
@@ -24,7 +24,8 @@ export const reactionRolesAddJSON = <AuxdibotSubcommand>{
       const channel = interaction.options.getChannel('channel', true, [ChannelType.GuildText]),
          roles = interaction.options.getString('roles', true),
          json = interaction.options.getString('json', true),
-         type = interaction.options.getString('type', false) || 'DEFAULT';
+         type = interaction.options.getString('type', false) || 'DEFAULT',
+         webhook_url = interaction.options.getString('webhook_url');
 
       if (!testLimit(interaction.data.guildData.reaction_roles, Limits.REACTION_ROLE_DEFAULT_LIMIT)) {
          return await handleError(
@@ -64,6 +65,7 @@ export const reactionRolesAddJSON = <AuxdibotSubcommand>{
          embed,
          undefined,
          ReactionRoleType[type],
+         webhook_url,
       )
          .then(async () => {
             const resEmbed = new EmbedBuilder().setColor(auxdibot.colors.accept).toJSON();

--- a/src/interfaces/Auxdibot.ts
+++ b/src/interfaces/Auxdibot.ts
@@ -6,6 +6,7 @@ import {
    EmbedBuilder,
    Message,
    InteractionReplyOptions,
+   InteractionResponse,
 } from 'discord.js';
 import AuxdibotCommand from './commands/AuxdibotCommand';
 import AuxdibotButton from './buttons/AuxdibotButton';
@@ -56,5 +57,5 @@ export interface Auxdibot extends Client {
       interaction: BaseInteraction,
       data: InteractionReplyOptions,
       options?: AuxdibotReplyOptions,
-   ): Promise<Message<boolean>> | Promise<void>;
+   ): Promise<Message<boolean> | InteractionResponse<boolean>>;
 }

--- a/src/modules/features/embeds/sendEmbed.ts
+++ b/src/modules/features/embeds/sendEmbed.ts
@@ -1,7 +1,24 @@
-import { Channel, APIEmbed } from 'discord.js';
+import { Channel, APIEmbed, WebhookClient } from 'discord.js';
 
-export default async function sendEmbed(channel: Channel, content?: string, embed?: APIEmbed) {
+export default async function sendEmbed(channel: Channel, content?: string, embed?: APIEmbed, webhook_url?: string) {
    if (!channel || !channel.isTextBased()) throw new Error("Can't send an embed to a non-text-based channel!");
+
+   if (webhook_url && !channel.isDMBased() && !channel.isThread()) {
+      if (!webhook_url.startsWith('https://discord.com/api/webhooks/')) throw new Error('Invalid Webhook URL!');
+      const webhooks = await channel.fetchWebhooks().catch(() => {
+         throw new Error('Auxdibot does not have permission to manage/view Webhooks in this channel!');
+      });
+      const webhook = webhooks.find((x) => x.url == webhook_url);
+      if (!webhook) throw new Error('Invalid Webhook URL!');
+      const client = new WebhookClient({ url: webhook_url });
+      return await client.send({ embeds: embed ? [embed] : undefined, content: content || '' }).catch((x) => {
+         if (x.code == 50027) throw new Error('Invalid Webhook URL!');
+         if (x.code == 50013)
+            throw new Error('Auxdibot does not have permission to send messages or use this webhook!');
+
+         throw new Error("Couldn't send that Embed!");
+      });
+   }
    return await channel.send({ embeds: embed ? [embed] : undefined, content: content || '' }).catch((x) => {
       if (x.code == '50013') throw new Error('Auxdibot does not have permission to send messages!');
       throw new Error("Couldn't send that Embed!");

--- a/src/modules/features/roles/reaction_roles/addReactionRole.ts
+++ b/src/modules/features/roles/reaction_roles/addReactionRole.ts
@@ -38,7 +38,8 @@ export default async function addReactionRole(
          .send({
             embeds: embed
                ? [embed]
-               : !content && [
+               : !content
+               ? [
                     new EmbedBuilder()
                        .setColor(auxdibot.colors.reaction_role)
                        .setTitle(title)
@@ -52,7 +53,8 @@ export default async function addReactionRole(
                           ),
                        )
                        .toJSON(),
-                 ],
+                 ]
+               : [],
             content: content || '',
          })
          .then(async (msg) => {
@@ -64,7 +66,8 @@ export default async function addReactionRole(
          .send({
             embeds: embed
                ? [embed]
-               : !content && [
+               : !content
+               ? [
                     new EmbedBuilder()
                        .setColor(auxdibot.colors.reaction_role)
                        .setTitle(title)
@@ -78,7 +81,8 @@ export default async function addReactionRole(
                           ),
                        )
                        .toJSON(),
-                 ],
+                 ]
+               : [],
             content: content || '',
          })
          .then(async (msg) => {

--- a/src/modules/features/roles/reaction_roles/addReactionRole.ts
+++ b/src/modules/features/roles/reaction_roles/addReactionRole.ts
@@ -1,6 +1,6 @@
 import { Auxdibot } from '@/interfaces/Auxdibot';
 import { ReactionRoleType } from '@prisma/client';
-import { Channel, EmbedBuilder, Guild, APIEmbed, Message } from 'discord.js';
+import { Channel, EmbedBuilder, Guild, APIEmbed, WebhookClient } from 'discord.js';
 import { parseReactionsAndRoles } from './parseReactionsAndRoles';
 import applyReactionRoles from './applyReactionRoles';
 
@@ -16,54 +16,95 @@ export default async function addReactionRole(
    embed?: APIEmbed,
    content?: string,
    type?: ReactionRoleType,
+   webhook_url?: string,
 ) {
+   if (['DEFAULT', 'STICKY_SELECT_ONE', 'STICKY', 'SELECT_ONE'].indexOf(type) == -1 && webhook_url) {
+      throw new Error('Webhooks are only supported for default reaction roles!');
+   }
+
    const reactionsAndRoles = await parseReactionsAndRoles(auxdibot, guild, reactions);
    if (reactionsAndRoles.length == 0) throw new Error('invalid reactions and roles');
    if (!channel || !channel.isTextBased()) throw new Error('invalid channel');
    let message = null;
-   return channel
-      .send({
-         embeds: embed
-            ? [embed]
-            : [
-                 new EmbedBuilder()
-                    .setColor(auxdibot.colors.reaction_role)
-                    .setTitle(title)
-                    .setDescription(
-                       reactionsAndRoles.reduce(
-                          (accumulator: string, item, index) =>
-                             `${accumulator}\r\n\r\n> **${index + 1})** ${
-                                auxdibot.emojis.cache.get(item.emoji) || item.emoji
-                             } - ${item.role}`,
-                          '',
-                       ),
-                    )
-                    .toJSON(),
-              ],
-         content: content || '',
-      })
-      .then(async (msg: Message) => {
-         message = msg;
-         applyReactionRoles(msg, reactionsAndRoles, type || ReactionRoleType.DEFAULT);
-         return auxdibot.database.servers
-            .update({
-               where: { serverID: guild.id },
-               data: {
-                  reaction_roles: {
-                     push: {
-                        messageID: msg.id,
-                        channelID: msg.channel.id,
-                        type,
-                        reactions: reactionsAndRoles.map((i) => ({ role: i.role.id, emoji: i.emoji })),
-                     },
-                  },
-               },
-            })
-            .then(() => true);
-      })
-      .catch((x) => {
-         if (message) message.delete().catch(() => undefined);
-         if (x.code == '50013') throw new Error('Auxdibot does not have permission to send messages!');
-         throw new Error('failed to send embed');
+   if (webhook_url && !channel.isDMBased() && !channel.isThread()) {
+      if (!webhook_url.startsWith('https://discord.com/api/webhooks/')) throw new Error('Invalid Webhook URL!');
+      const webhooks = await channel.fetchWebhooks().catch(() => {
+         throw new Error('Auxdibot does not have permission to manage/view Webhooks in this channel!');
       });
+      const webhook = webhooks.find((x) => x.url == webhook_url);
+      if (!webhook) throw new Error('Invalid Webhook URL!');
+      const client = new WebhookClient({ url: webhook_url });
+      await client
+         .send({
+            embeds: embed
+               ? [embed]
+               : !content && [
+                    new EmbedBuilder()
+                       .setColor(auxdibot.colors.reaction_role)
+                       .setTitle(title)
+                       .setDescription(
+                          reactionsAndRoles.reduce(
+                             (accumulator: string, item, index) =>
+                                `${accumulator}\r\n\r\n> **${index + 1})** ${
+                                   auxdibot.emojis.cache.get(item.emoji) || item.emoji
+                                } - ${item.role}`,
+                             '',
+                          ),
+                       )
+                       .toJSON(),
+                 ],
+            content: content || '',
+         })
+         .then(async (msg) => {
+            message = msg;
+            applyReactionRoles(msg.id, channel, reactionsAndRoles, type);
+         });
+   } else {
+      await channel
+         .send({
+            embeds: embed
+               ? [embed]
+               : !content && [
+                    new EmbedBuilder()
+                       .setColor(auxdibot.colors.reaction_role)
+                       .setTitle(title)
+                       .setDescription(
+                          reactionsAndRoles.reduce(
+                             (accumulator: string, item, index) =>
+                                `${accumulator}\r\n\r\n> **${index + 1})** ${
+                                   auxdibot.emojis.cache.get(item.emoji) || item.emoji
+                                } - ${item.role}`,
+                             '',
+                          ),
+                       )
+                       .toJSON(),
+                 ],
+            content: content || '',
+         })
+         .then(async (msg) => {
+            message = msg;
+            applyReactionRoles(msg.id, channel, reactionsAndRoles, type);
+         })
+         .catch((x) => {
+            if (message) message.delete().catch(() => undefined);
+            if (x.code == '50013') throw new Error('Auxdibot does not have permission to send messages!');
+            throw new Error('failed to send embed');
+         });
+   }
+
+   return auxdibot.database.servers
+      .update({
+         where: { serverID: guild.id },
+         data: {
+            reaction_roles: {
+               push: {
+                  messageID: message.id,
+                  channelID: channel.id,
+                  type,
+                  reactions: reactionsAndRoles.map((i) => ({ role: i.role.id, emoji: i.emoji })),
+               },
+            },
+         },
+      })
+      .then(() => true);
 }

--- a/src/modules/features/roles/reaction_roles/applyReactionRoles.ts
+++ b/src/modules/features/roles/reaction_roles/applyReactionRoles.ts
@@ -4,16 +4,20 @@ import {
    ActionRowBuilder,
    ButtonBuilder,
    ButtonStyle,
-   Message,
+   Channel,
    StringSelectMenuBuilder,
    StringSelectMenuOptionBuilder,
 } from 'discord.js';
 
 export default async function applyReactionRoles(
-   msg: Message,
+   msgID: string,
+   channel: Channel,
    reactionsAndRoles: ReactionsAndRolesBuilder[],
    type: ReactionRoleType,
 ) {
+   if (!channel.isTextBased()) return;
+   const message = msgID ? await channel.messages.fetch(msgID) : null;
+   if (!message) return;
    let rows: ActionRowBuilder<ButtonBuilder | StringSelectMenuBuilder>[] = [
       new ActionRowBuilder<StringSelectMenuBuilder>(),
    ];
@@ -22,7 +26,7 @@ export default async function applyReactionRoles(
       case ReactionRoleType.STICKY_SELECT_ONE:
       case ReactionRoleType.STICKY:
       case ReactionRoleType.SELECT_ONE:
-         reactionsAndRoles.forEach((i) => msg.react(i.emoji).catch(() => undefined));
+         reactionsAndRoles.forEach((i) => message.react(i.emoji).catch(() => undefined));
          break;
       case ReactionRoleType.BUTTON:
       case ReactionRoleType.BUTTON_SELECT_ONE:
@@ -61,8 +65,10 @@ export default async function applyReactionRoles(
          );
    }
    if (rows.find((i) => i.components.length > 0)) {
-      await msg.edit({
-         components: rows.map((i) => i.toJSON()),
-      });
+      await message
+         .edit({
+            components: rows.map((i) => i.toJSON()),
+         })
+         .catch(() => undefined);
    }
 }

--- a/src/modules/features/roles/reaction_roles/applyReactionsToMessage.ts
+++ b/src/modules/features/roles/reaction_roles/applyReactionsToMessage.ts
@@ -17,7 +17,7 @@ export async function applyReactionsToMessages(
    const reactionsAndRoles = await parseReactionsAndRoles(auxdibot, guild, reactions);
    if (reactionsAndRoles.length == 0) throw new Error('invalid reactions and roles');
    if (!message || !message.channel.isTextBased() || message.guild != guild) throw new Error('invalid message');
-   applyReactionRoles(message, reactionsAndRoles, type ?? ReactionRoleType.DEFAULT);
+   applyReactionRoles(message.id, message.channel, reactionsAndRoles, type ?? ReactionRoleType.DEFAULT);
    return auxdibot.database.servers
       .update({
          where: { serverID: guild.id },

--- a/src/server/servers/routes/embeds.ts
+++ b/src/server/servers/routes/embeds.ts
@@ -23,7 +23,13 @@ const embeds = (auxdibot: Auxdibot, router: Router) => {
                ? (JSON.parse(await parsePlaceholders(auxdibot, req.body['embed'], req.guild)) satisfies APIEmbed)
                : undefined;
             if (!channel || !channel.isTextBased()) return res.status(400).json({ error: 'invalid channel' });
-            return sendEmbed(channel, await parsePlaceholders(auxdibot, req.body['message'], req.guild), embed)
+            const webhook_url = req.body['webhook_url'];
+            return sendEmbed(
+               channel,
+               await parsePlaceholders(auxdibot, req.body['message'], req.guild),
+               embed,
+               webhook_url,
+            )
                .then(() => res.json({ success: 'successfully sent embed to ' + channel.name }))
                .catch((x) => {
                   res.status(500).json({ error: x.message });

--- a/src/server/servers/routes/reaction_roles.ts
+++ b/src/server/servers/routes/reaction_roles.ts
@@ -69,15 +69,18 @@ const reactionRoles = (auxdibot: Auxdibot, router: Router) => {
                }
                if (!req.body['channel']) return res.status(400).json({ error: 'missing parameters' });
                const channel = req.guild.channels.cache.get(req.body['channel']);
+               const webhook_url = req.body['webhook_url'];
+               console.log(embed);
                return addReactionRole(
                   auxdibot,
                   req.guild,
                   channel,
                   title,
                   reactionsParsed,
-                  embed,
+                  embed ?? undefined,
                   await parsePlaceholders(auxdibot, req.body['message'], req.guild),
                   type,
+                  webhook_url ?? undefined,
                )
                   .then((i) => res.json({ created: i }))
                   .catch((x) =>

--- a/src/util/createReply.ts
+++ b/src/util/createReply.ts
@@ -1,6 +1,6 @@
 import { Auxdibot } from '@/interfaces/Auxdibot';
 import findOrCreateServer from '@/modules/server/findOrCreateServer';
-import { BaseInteraction, InteractionReplyOptions, MessagePayload } from 'discord.js';
+import { BaseInteraction, InteractionReplyOptions, InteractionResponse, Message, MessagePayload } from 'discord.js';
 import { AuxdibotReplyOptions } from '../interfaces/AuxdibotReplyOptions';
 import handleLog from './handleLog';
 
@@ -9,7 +9,7 @@ export async function createReply(
    interaction: BaseInteraction,
    data: InteractionReplyOptions,
    options?: AuxdibotReplyOptions,
-): Promise<void> {
+): Promise<Message<boolean> | InteractionResponse<boolean>> {
    if (interaction.guildId && interaction.isChatInputCommand() && !options?.noOutputChannel) {
       const server = await findOrCreateServer(this, interaction.guildId);
       if (!server) return;
@@ -72,7 +72,7 @@ export async function createReply(
       }
    }
 
-   interaction.isRepliable() && interaction.deferred
+   return interaction.isRepliable() && interaction.deferred
       ? interaction.editReply(data)
       : interaction.isRepliable() && !interaction.replied
       ? interaction.reply(data)


### PR DESCRIPTION
* Implemented the `webhook_url` parameter in Embeds and Reaction Roles, in REST API endpoints and commands.
* Fixed `/embeds json` command by making Auxdibot share the Embed JSON as a file.
* Updated to version 2.7.1

Closes #162 