### PR TITLE
fix(djs): We love discord.js ( I don't )

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
       "@types/passport-discord": "^0.1.13",
       "axios": "^1.7.2",
       "cors": "^2.8.5",
-      "discord.js": "^14.15.2",
+      "discord.js": "^14.14.1",
       "emoji-regex": "^10.3.0",
       "express": "^4.19.2",
       "express-rate-limit": "^7.2.0",


### PR DESCRIPTION
DJS has decided to suck, here's an update to revert back to old version.

Documented issue:
this.entitlements = data.entitlements.reduce(
                                          ^

TypeError: Cannot read properties of undefined (reading 'reduce')