### PR TITLE
feat(modules): disable levels in default server

### DIFF
--- a/src/constants/database/defaultServer.ts
+++ b/src/constants/database/defaultServer.ts
@@ -12,6 +12,7 @@ export const defaultServer: Partial<servers> = {
    join_embed: DEFAULT_JOIN_EMBED as APIEmbed,
    leave_embed: DEFAULT_LEAVE_EMBED as APIEmbed,
    level_message: { content: '', embed: DEFAULT_LEVELUP_EMBED as APIEmbed },
+   disabled_modules: ['Levels'],
    suggestions: [],
    punishments: [],
    starred_messages: [],


### PR DESCRIPTION
* Disabled levels by default, because they can interfere with server activities, but should be setup by the owner manually using the `/setup levels` command