### PR TITLE
fix(levels): disable leaderboard button when leaderboard is private

### DIFF
--- a/src/interaction/subcommands/levels/levelsStats.ts
+++ b/src/interaction/subcommands/levels/levelsStats.ts
@@ -39,7 +39,8 @@ export const levelsStats = <AuxdibotSubcommand>{
             .setURL(`${process.env.BOT_HOMEPAGE}/leaderboard/${interaction.data.guild.id}`)
             .setEmoji(CustomEmojis.LEVELS)
             .setLabel('Leaderboard')
-            .setStyle(ButtonStyle.Link),
+            .setStyle(ButtonStyle.Link)
+            .setDisabled(!interaction.data.guildData.publicize_leaderboard),
          new ButtonBuilder()
             .setCustomId('levelembed-' + user.id)
             .setLabel('View Legacy Embed')

--- a/src/modules/features/levels/generateLeaderboardEmbed.ts
+++ b/src/modules/features/levels/generateLeaderboardEmbed.ts
@@ -52,7 +52,8 @@ export async function generateLeaderboardEmbed(auxdibot: Auxdibot, guild: Guild,
                .setURL(`${process.env.BOT_HOMEPAGE}/leaderboard/${guild.id}`)
                .setEmoji(CustomEmojis.BOLT)
                .setLabel('View Leaderboard')
-               .setStyle(ButtonStyle.Link),
+               .setStyle(ButtonStyle.Link)
+               .setDisabled(!server.publicize_leaderboard),
          ),
    ].filter((i) => i);
    return { embed, row };


### PR DESCRIPTION
* Disabled leaderboard button on `/mylevel` and `/levels stats level` if leaderboard is not public.
