### PR TITLE
fix(logs): ` for code and code blocks broke log formatting for edit message

### DIFF
--- a/src/interaction/events/message/messageDelete.ts
+++ b/src/interaction/events/message/messageDelete.ts
@@ -70,7 +70,7 @@ export default async function messageDelete(auxdibot: Auxdibot, message: Message
             name: 'Deleted Message',
             value: `${executorCheck ? `Executor: ${executorCheck}` : ''}\nAuthor: ${message.author}\nChannel: ${
                message.channel
-            }\n\n**Deleted Content** \n\`\`\`${message.cleanContent}\`\`\``,
+            }\n\n**Deleted Content** \n\`\`\`${message.cleanContent.replaceAll('`', '')}\`\`\``,
             inline: false,
          },
       ],

--- a/src/interaction/events/message/messageUpdate.ts
+++ b/src/interaction/events/message/messageUpdate.ts
@@ -38,8 +38,10 @@ export default async function messageUpdate(
                } ([Original Message](https://discord.com/channels/${newMessage.guildId}/${newMessage.channelId}/${
                   newMessage.id
                }))${
-                  oldMessage.content ? `\n\n**Old Message** \n\`\`\`${oldMessage.content}\`\`\`` : ''
-               }\n\n**New Message** \n\`\`\`${newMessage.cleanContent}\`\`\``,
+                  oldMessage.content
+                     ? `\n\n**Old Message** \n\`\`\`${oldMessage.content.replaceAll('`', '')}\`\`\``
+                     : ''
+               }\n\n**New Message** \n\`\`\`${newMessage.cleanContent.replaceAll('`', '')}\`\`\``,
                inline: false,
             },
          ],


### PR DESCRIPTION
The character "`" would cause log messages to escape the code block. The commit will fix it.