### PR TITLE
fix(fetch): implement catch's for various fetch statements to prevent crashes, fix runtime errors

### DIFF
--- a/src/interaction/events/guild/guildMemberAdd.ts
+++ b/src/interaction/events/guild/guildMemberAdd.ts
@@ -10,29 +10,32 @@ export default async function guildMemberAdd(auxdibot: Auxdibot, member: GuildMe
    if (!member) return;
    const server = await findOrCreateServer(auxdibot, member.guild.id);
    if (server.join_leave_channel && server.disabled_modules.indexOf('Greetings') == -1) {
-      member.guild.channels.fetch(server.join_leave_channel).then(async (channel) => {
-         if (channel && channel.isTextBased()) {
-            if (server.join_embed || server.join_text) {
-               await channel
-                  .send({
-                     content: `${server.join_text || ''}`,
-                     ...(Object.entries(server.join_embed || {}).length != 0
-                        ? {
-                             embeds: [
-                                JSON.parse(
-                                   await parsePlaceholders(auxdibot, JSON.stringify(server.join_embed), {
-                                      guild: member.guild,
-                                      member,
-                                   }),
-                                ) as APIEmbed,
-                             ],
-                          }
-                        : {}),
-                  })
-                  .catch((x) => console.error(x));
+      member.guild.channels
+         .fetch(server.join_leave_channel)
+         .then(async (channel) => {
+            if (channel && channel.isTextBased()) {
+               if (server.join_embed || server.join_text) {
+                  await channel
+                     .send({
+                        content: `${server.join_text || ''}`,
+                        ...(Object.entries(server.join_embed || {}).length != 0
+                           ? {
+                                embeds: [
+                                   JSON.parse(
+                                      await parsePlaceholders(auxdibot, JSON.stringify(server.join_embed), {
+                                         guild: member.guild,
+                                         member,
+                                      }),
+                                   ) as APIEmbed,
+                                ],
+                             }
+                           : {}),
+                     })
+                     .catch((x) => console.error(x));
+               }
             }
-         }
-      });
+         })
+         .catch(() => undefined);
    }
    if ((server.join_dm_embed || server.join_dm_text) && server.disabled_modules.indexOf('Greetings') == -1) {
       await member

--- a/src/interaction/events/guild/guildMemberRemove.ts
+++ b/src/interaction/events/guild/guildMemberRemove.ts
@@ -10,29 +10,32 @@ export default async function guildMemberRemove(auxdibot: Auxdibot, member: Guil
    if (!member) return;
    const server = await findOrCreateServer(auxdibot, member.guild.id);
    if (server.join_leave_channel && server.disabled_modules.indexOf('Greetings') == -1) {
-      member.guild.channels.fetch(server.join_leave_channel).then(async (channel) => {
-         if (channel && channel.isTextBased()) {
-            if (server.leave_text || server.leave_embed) {
-               channel
-                  .send({
-                     content: `${server.leave_text || ''}`,
-                     ...(Object.entries(server.leave_embed || {}).length != 0
-                        ? {
-                             embeds: [
-                                JSON.parse(
-                                   await parsePlaceholders(auxdibot, JSON.stringify(server.leave_embed), {
-                                      guild: member.guild,
-                                      member,
-                                   }),
-                                ) as APIEmbed,
-                             ],
-                          }
-                        : {}),
-                  })
-                  .catch(() => undefined);
+      member.guild.channels
+         .fetch(server.join_leave_channel)
+         .then(async (channel) => {
+            if (channel && channel.isTextBased()) {
+               if (server.leave_text || server.leave_embed) {
+                  channel
+                     .send({
+                        content: `${server.leave_text || ''}`,
+                        ...(Object.entries(server.leave_embed || {}).length != 0
+                           ? {
+                                embeds: [
+                                   JSON.parse(
+                                      await parsePlaceholders(auxdibot, JSON.stringify(server.leave_embed), {
+                                         guild: member.guild,
+                                         member,
+                                      }),
+                                   ) as APIEmbed,
+                                ],
+                             }
+                           : {}),
+                     })
+                     .catch(() => undefined);
+               }
             }
-         }
-      });
+         })
+         .catch(() => undefined);
    }
    memberLeave(auxdibot, member.guild.id, member);
    await handleLog(

--- a/src/interaction/subcommands/moderation/lock/lockServer.ts
+++ b/src/interaction/subcommands/moderation/lock/lockServer.ts
@@ -59,7 +59,7 @@ export const lockServer = <AuxdibotSubcommand>{
          description: `The server was locked.`,
       });
       await auxdibot.createReply(interaction, { embeds: [embed] });
-      const channels = await interaction.guild.channels.fetch();
+      const channels = await interaction.guild.channels.fetch().catch(() => []);
       for (const channel of channels.values()) {
          if (!channel.isDMBased() && channel.isTextBased()) {
             const lock = <ChannelLock>{

--- a/src/interaction/subcommands/moderation/unlock/unlockServer.ts
+++ b/src/interaction/subcommands/moderation/unlock/unlockServer.ts
@@ -39,7 +39,8 @@ export const unlockServer = <AuxdibotSubcommand>{
       handleLog(auxdibot, interaction.guild, log);
       await auxdibot.createReply(interaction, { embeds: [embed] });
       for (const locked of server.locked_channels) {
-         const channel = await interaction.guild.channels.fetch(locked.channelID);
+         const channel = await interaction.guild.channels.fetch(locked.channelID).catch(() => undefined);
+         if (!channel) continue;
          if (channel.isThread()) {
             return await channel
                .setLocked(false)

--- a/src/interaction/subcommands/suggestions/suggestionsCreate.ts
+++ b/src/interaction/subcommands/suggestions/suggestionsCreate.ts
@@ -39,7 +39,7 @@ export const suggestionsCreate = <AuxdibotSubcommand>{
          );
       }
       const suggestions_channel = server.suggestions_channel
-         ? await interaction.data.guild.channels.fetch(server.suggestions_channel)
+         ? await interaction.data.guild.channels.fetch(server.suggestions_channel).catch(() => undefined)
          : undefined;
       if (!suggestions_channel || !suggestions_channel.isTextBased()) {
          return await handleError(

--- a/src/modules/analytics/fetchAnalytics.ts
+++ b/src/modules/analytics/fetchAnalytics.ts
@@ -1,7 +1,7 @@
 import { Auxdibot } from '@/interfaces/Auxdibot';
 
 export default async function fetchAnalytics(auxdibot: Auxdibot) {
-   await auxdibot.guilds.fetch();
+   await auxdibot.guilds.fetch().catch(() => null);
    const analytics = {
       servers: auxdibot.guilds.cache.size,
       members: auxdibot.guilds.cache.reduce((acc, i) => acc + i.memberCount, 0),

--- a/src/modules/features/levels/createUserVCSchedule.ts
+++ b/src/modules/features/levels/createUserVCSchedule.ts
@@ -8,13 +8,14 @@ import { calculateLevel } from './calculateLevel';
 
 export function createUserVCSchedule(auxdibot: Auxdibot, member: GuildMember) {
    const task = new AsyncTask(member.id + ' vclevels', async (taskId) => {
-      member = await member.fetch().catch(() => undefined);
+      member = await member?.fetch().catch(() => undefined);
       if (member.user.bot) return;
       const server = await auxdibot.database.servers
          .findFirst({ where: { serverID: member.guild.id } })
          .catch(() => undefined);
       if (
          !member ||
+         member.user.bot ||
          !server ||
          (server.voice_xp_range[0] == 0 && !server.voice_xp_range[1]) ||
          member.voice.channelId === null

--- a/src/modules/features/massrole/massroleMembers.ts
+++ b/src/modules/features/massrole/massroleMembers.ts
@@ -10,7 +10,8 @@ export default async function massroleMembers(
    give: boolean,
    user?: { id: string },
 ) {
-   const members = await guild.members.fetch();
+   const members = await guild.members.fetch().catch(() => undefined);
+   if (!members) return 0;
    members.forEach((member) => {
       if (
          user.id != member.id &&

--- a/src/modules/features/moderation/lock/scheduleChannelUnlocks.ts
+++ b/src/modules/features/moderation/lock/scheduleChannelUnlocks.ts
@@ -19,7 +19,8 @@ export default function scheduleChannelUnlocks(auxdibot: Auxdibot) {
                });
                if (expired) {
                   for (const expiredLock of expired) {
-                     const channel = await guild.channels.fetch(expiredLock.channelID);
+                     const channel = await guild.channels.fetch(expiredLock.channelID).catch(() => undefined);
+                     if (!channel) continue;
                      if (channel.isThread()) {
                         await channel
                            .setLocked(false)

--- a/src/util/hasPremium.ts
+++ b/src/util/hasPremium.ts
@@ -1,5 +1,9 @@
-import { Auxdibot } from '@/interfaces/Auxdibot';
+// Commented out prior to adding DJS new version
+
+/*import { Auxdibot } from '@/interfaces/Auxdibot';
 import { Guild } from 'discord.js';
+
+
 
 export async function hasPremium(auxdibot: Auxdibot, guild: Guild) {
    if (!process.env.PREMIUM_SKU_ID) return true;
@@ -7,4 +11,4 @@ export async function hasPremium(auxdibot: Auxdibot, guild: Guild) {
       guild &&
       (await auxdibot.application.entitlements.fetch({ guild: guild?.id, skus: [process.env.PREMIUM_SKU_ID] }));
    return !entitlements || entitlements.filter((i) => i.skuId == process.env.PREMIUM_SKU_ID).size === 0;
-}
+}*/


### PR DESCRIPTION
* fix crashes by plopping .catch(() => undefined) in various places
* fix "Error while handling task XXXXXX vclevels: Cannot read properties of undefined (reading 'fetch')" error in console when someones in vc