### PR TITLE
feat: update permissions that use Administrator to be ManageGuild

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
    "packages": {
       "": {
          "name": "auxdibot",
-         "version": "2.10.0",
+         "version": "2.10.2",
          "license": "MPL-2.0",
          "dependencies": {
             "@napi-rs/canvas": "^0.1.53",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
    "name": "auxdibot",
-   "version": "2.10.0",
+   "version": "2.10.2",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "auxdibot",
-   "version": "2.10.0",
+   "version": "2.10.2",
    "description": "Main repo for the Auxdibot discord.js bot, utilizing TypeScript and express for endpoints.",
    "main": "./dist/index.js",
    "scripts": {

--- a/src/interaction/commands/greetings/greetings.ts
+++ b/src/interaction/commands/greetings/greetings.ts
@@ -76,7 +76,7 @@ export default <AuxdibotCommand>{
       module: Modules['Greetings'],
       description: 'Change settings for greetings on the server.',
       usageExample: '/greetings (channel|join|join_dm|leave)',
-      permissionsRequired: [PermissionFlagsBits.Administrator],
+      permissionsRequired: [PermissionFlagsBits.ManageGuild],
    },
    subcommands: [greetingsChannel, joinMessage, joinPreview, leaveMessage, leavePreview, joinDMMessage, joinDMPreview],
    async execute() {

--- a/src/interaction/commands/levels/levels.ts
+++ b/src/interaction/commands/levels/levels.ts
@@ -347,7 +347,7 @@ export default <AuxdibotCommand>{
       module: Modules['Levels'],
       description: 'Change settings for leveling on this server.',
       usageExample: '/levels (settings|message|multipliers|data|rewards|xp|stats|disable_messages)',
-      permissionsRequired: [PermissionFlagsBits.Administrator],
+      permissionsRequired: [PermissionFlagsBits.ManageGuild],
    },
    subcommands: [
       addLevelReward,

--- a/src/interaction/commands/settings/commands.ts
+++ b/src/interaction/commands/settings/commands.ts
@@ -284,7 +284,7 @@ export default <AuxdibotCommand>{
       module: Modules['Settings'],
       description: "Manage access for all of Auxdibot's commands.",
       usageExample: '/commands',
-      permissionsRequired: [PermissionFlagsBits.Administrator],
+      permissionsRequired: [PermissionFlagsBits.ManageGuild],
    },
    subcommands: [
       commandsAdminSet,

--- a/src/interaction/commands/settings/logs.ts
+++ b/src/interaction/commands/settings/logs.ts
@@ -40,7 +40,7 @@ export default <AuxdibotCommand>{
       module: Modules['Settings'],
       description: 'Manage how Auxdibot logs events on your server.',
       usageExample: '/logs (latest|filter|list_filtered|channel|actions)',
-      permissionsRequired: [PermissionFlagsBits.Administrator],
+      permissionsRequired: [PermissionFlagsBits.ManageGuild],
    },
    subcommands: [logsLogChannel, logsLatest, logsActions, logsListFiltered, logsFilter],
    async execute() {

--- a/src/interaction/commands/settings/modules.ts
+++ b/src/interaction/commands/settings/modules.ts
@@ -45,7 +45,7 @@ export default <AuxdibotCommand>{
       module: Modules['Settings'],
       description: "Manage Auxdibot's modules. (/help modules)",
       usageExample: '/modules (disable|enable) (module)',
-      permissionsRequired: [PermissionFlagsBits.Administrator],
+      permissionsRequired: [PermissionFlagsBits.ManageGuild],
    },
    subcommands: [moduleDisable, moduleEnable],
    async execute() {

--- a/src/interaction/commands/settings/settings.ts
+++ b/src/interaction/commands/settings/settings.ts
@@ -16,7 +16,7 @@ export default <AuxdibotCommand>{
       module: Modules['Settings'],
       description: 'Change settings for the server.',
       usageExample: '/settings (view|reset)',
-      permissionsRequired: [PermissionFlagsBits.Administrator],
+      permissionsRequired: [PermissionFlagsBits.ManageGuild],
    },
    subcommands: [settingsView, settingsReset],
    async execute() {

--- a/src/interaction/commands/settings/setup.ts
+++ b/src/interaction/commands/settings/setup.ts
@@ -45,7 +45,7 @@ export default <AuxdibotCommand>{
       module: Modules['Settings'],
       description: "Setup one or all of Auxdibot's features.",
       usageExample: '/setup (auto|starboard|levels|suggestions|moderation|greetings)',
-      permissionsRequired: [PermissionFlagsBits.Administrator],
+      permissionsRequired: [PermissionFlagsBits.ManageGuild],
    },
    subcommands: [setupAuto, setupStarboard, setupLevels, setupSuggestions, setupModeration, setupGreetings],
    async execute() {

--- a/src/interaction/commands/starboard/starboard.ts
+++ b/src/interaction/commands/starboard/starboard.ts
@@ -144,7 +144,7 @@ export default <AuxdibotCommand>{
       module: Modules['Starboard'],
       description: 'Change the starboard settings for this server.',
       usageExample: '/starboard (board|settings)',
-      permissionsRequired: [PermissionFlagsBits.Administrator],
+      permissionsRequired: [PermissionFlagsBits.ManageGuild],
    },
    subcommands: [
       starboardBoardCreate,

--- a/src/interaction/commands/suggestions/suggestions.ts
+++ b/src/interaction/commands/suggestions/suggestions.ts
@@ -167,7 +167,7 @@ export default <AuxdibotCommand>{
       description: 'The main command for handling suggestions on this server.',
       usageExample:
          '/suggestions (create|channel|updates_channel|auto_delete|discussion_threads|reactions|remove_reaction|add_reaction|respond|ban|unban|delete)',
-      permissionsRequired: [PermissionFlagsBits.Administrator],
+      permissionsRequired: [PermissionFlagsBits.ManageGuild],
    },
    subcommands: [
       suggestionsCreate,


### PR DESCRIPTION
* ManageGuild more accurately reflects what being able to edit server settings is. Giving a user Administrator is giving them full owner permissions - the actual ownership of the server, this isn't appropriate for what it actually does.
* update to 2.10.2